### PR TITLE
fix: `BSP_ASSERT` 宏尾随分号

### DIFF
--- a/BSP/bsp_def.h
+++ b/BSP/bsp_def.h
@@ -23,7 +23,12 @@ __attribute__((unused)) static void bsp_assert_err(const char* file, uint32_t li
     bsp_led_set(255, 0, 0);
     while(1) __NOP();
 }
-#define BSP_ASSERT(arg) if(!(arg)) bsp_assert_err(__FILE__, __LINE__);
+
+#define BSP_ASSERT(arg)                         \
+	do {                                        \
+		if(!(arg))                              \
+			bsp_assert_err(__FILE__, __LINE__); \
+	} while(0)
 
 typedef enum {
     BSP_OK = 0,


### PR DESCRIPTION
目前 `BSP_ASSERT` 宏使用时尾随分号存在 `Empty statement` 警告:
```
// BSP/bsp_uart.c:22
BSP_ASSERT(callback[e] == NULL);
                               ^ Empty statement
```